### PR TITLE
SQL-PDF-Vala: Minor fixes / experiments.

### DIFF
--- a/reporter-cli/sql-pdf/vala/src/Makefile
+++ b/reporter-cli/sql-pdf/vala/src/Makefile
@@ -40,7 +40,7 @@ BIN_DIR         = ../bin
 
 # Specify flags and other vars here.
 VC      = valac
-VCFLAGS = --target-glib=2.40 --pkg=posix
+VCFLAGS = --target-glib=2.40 -X -s -X -O3 --pkg=posix
 
 SUDO    = sudo
 LN      = ln

--- a/reporter-cli/sql-pdf/vala/src/reporter_model.vala
+++ b/reporter-cli/sql-pdf/vala/src/reporter_model.vala
@@ -232,8 +232,8 @@ class ReporterModel {
 //       marks ('?'). And SQLite client lib (sqlite3) can handle question-mark-
 //       placeholders too, but without any extra stuff around them (?).
 //       Thus, for both MySQL and SQLite libs it is possible to use a unified
-//       notation, but for SQLite ops it needs to make some post-processing
-//       with the query string -- see below.
+//       notation, but for SQLite ops it needs to make some preprocessing
+//       of the query string -- see below.
 // ----------------------------------------------------------------------------
    #if (POSTGRES)
 //          + " (attr_x3   >=    $1) and"
@@ -298,7 +298,7 @@ class ReporterModel {
         var num_rows = res_set.get_n_tuples();
         var num_hdrs = res_set.get_n_fields();
  #elif (SQLITE)
-        // Removing single quotation marks from SQL placeholders.
+        // Removing single quotation marks from SQL placehldrs (preprocessing).
         sql_select = sql_select.replace(aux._SQ, aux._EMPTY_STRING);
 
         Statement stmt;


### PR DESCRIPTION
* Commentary fix: replacing "**post-processing with**" to "**preprocessing of**".
* Inner Makefile change: **Optimizing binaries** at **C level**:
  * **-X -s** &ndash; Remove all symbol table and relocation information from the executable.
(See: https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html )
  * **-X -O3** &ndash; Optimize yet more. -O3 turns on all optimizations specified by -O2 and also turns on the -finline-functions, -funswitch-loops, -fpredictive-commoning, -fgcse-after-reload, -ftree-loop-vectorize, -ftree-loop-distribute-patterns, -fsplit-paths -ftree-slp-vectorize, -fvect-cost-model, -ftree-partial-pre, -fpeel-loops and -fipa-cp-clone options.
(See: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html )